### PR TITLE
Bump version to Veribit v0.0.7 alpha

### DIFF
--- a/veribit-admin/package.json
+++ b/veribit-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Veribit",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Veribit Admin",
   "private": true,
   "repository": {

--- a/veribit-be/package.json
+++ b/veribit-be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Veribit",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Veribit Backend",
   "main": "src/app.js",
   "scripts": {

--- a/veribit-fe/package.json
+++ b/veribit-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Veribit",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Veribit Front End",
   "private": true,
   "repository": {


### PR DESCRIPTION
This build contains the addition of image compression for the takePhotoContainer and for the selfie/doc upload with a target set for 0.09MB. Various buttons have been migrated to use the Veribit branded buttons for this build. There are also CVE patches for Mongoose and Pillow libraries.